### PR TITLE
Fix failing on mask different from and_mask

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -156,7 +156,7 @@ template<class Callback> bool for_each_bitfield( Callback cb, tinfo_t type, uint
 			continue;
 
 		uint64_t mask = bitfield_access_mask( member );
-		if ( member.size != 1 && ( and_mask & mask ) != mask )
+		if ( member.size != 1 && ( and_mask & mask ) != and_mask )
 		{
 			msg( "[bitfields] bad offset (%ull) and size (%ull) combo of a field for given mask (%ull)\n", member.offset, member.size, and_mask );
 			return false;


### PR DESCRIPTION
It seems to me that at https://github.com/JustasMasiulis/ida_bitfields/blob/master/plugin.cpp#L159
that the comparison
( and_mask & mask ) != mask 
is wrong, because it will cause the plugin to fail on the wrong condition,
I think what you meant was to fail if the and_mask is bigger than the mask which means that the and_mask doesn't fit the field.
because for example if mask is 0xFFFF and and_mask is 0x1000
after https://github.com/JustasMasiulis/ida_bitfields/blob/master/plugin.cpp#L396
The check would fail because ( 0xFFFF & 0x1000 ) !=  0xFFFF, but logically it is a valid